### PR TITLE
Bug fix get_pod_list when pod doesn't have metadata.owner_reference

### DIFF
--- a/kubecustom/pod.py
+++ b/kubecustom/pod.py
@@ -65,7 +65,8 @@ def get_pod_list(deployment_name=None, namespace=None):
         pods = [
             pod
             for pod in pods.items
-            if all(
+            if pod.metadata.owner_references is not None
+            and all(
                 owner.kind == "ReplicaSet"
                 and "-".join(owner.name.split("-")[:-1]) == deployment_name
                 for owner in pod.metadata.owner_references


### PR DESCRIPTION
When a dask cluster is running, some pods don't have `metadata.owner_reference` fields. This PR will skip those pods when identifying the deployment that a pod belongs to.