### PR TITLE
Add pod monitor

### DIFF
--- a/kubecustom/__main__.py
+++ b/kubecustom/__main__.py
@@ -3,7 +3,7 @@ import time
 import warnings
 
 from .deployment import utilization_per_deployment
-from .utils import get_parser
+from .utils import get_parser, repeat_task
 
 parser = get_parser()
 args = parser.parse_args()
@@ -14,13 +14,9 @@ silence = kwargs.pop("silence")
 if silence:
     warnings.filterwarnings("ignore")
 
-
-def repeat_task(scheduler):
-    scheduler.enter(timelag, 1, repeat_task, (scheduler,))
-    utilization_per_deployment(**kwargs)
-
-
 utilization_per_deployment(**kwargs)
 my_scheduler = sched.scheduler(time.time, time.sleep)
-my_scheduler.enter(timelag, 1, repeat_task, (my_scheduler,))
+my_scheduler.enter(
+    timelag, 1, repeat_task, (my_scheduler, utilization_per_deployment, kwargs, timelag)
+)
 my_scheduler.run()

--- a/kubecustom/kubecustom.py
+++ b/kubecustom/kubecustom.py
@@ -1,13 +1,18 @@
 """Combined functions expected to be of most common use."""
 
+import sched
+import time
+import warnings
 import os
 import yaml
 import shutil
+import pandas as pd
 from pkg_resources import resource_filename
 
-from .utils import file_find_replace, load_template_paths
+from .utils import file_find_replace, load_template_paths, repeat_task
 from .secret import create_secret, delete_secret, MyData
-from .deployment import create_deployment, delete_deployment
+from .deployment import create_deployment, delete_deployment, get_deployments
+from .pod import get_pods_status_info
 
 
 with open(resource_filename("kubecustom", "template_files/template_keys.yaml")) as f:
@@ -115,3 +120,132 @@ def delete_secret_deployment(deployment_name, namespace=None, verbose=True):
     namespace = MyDataInstance.get_data("namespace") if namespace is None else namespace
     delete_secret(deployment_name, namespace=namespace, verbose=verbose)
     delete_deployment(deployment_name, namespace=namespace, verbose=verbose)
+
+
+def update_pods_status_info(filename="pod_log.csv", keep_key="", namespace=None):
+    """Update file with status and IP address information for pods, optionally filtered by deployment.
+
+    Args:
+        filename (str, optional): Filename to store pod information. Defaults to "pod_log.csv",
+        keep_key (str, optional): A string in the deployment name to signify that it should be kept. Defaults to "".
+        namespace (str, optional): Kubernetes descriptor to indicate a set of team resources. Defaults to
+        :func:`kubecustom.secret.MyData.get_data```("namespace")``.
+    """
+    namespace = MyDataInstance.get_data("namespace") if namespace is None else namespace
+
+    deployments = get_deployments(namespace=namespace)
+    deployment_names = [
+        dep.metadata.name for dep in deployments if keep_key in dep.metadata.name
+    ]
+
+    fname_complete = ".".join(filename.split(".")[:-1]) + "_complete.csv"
+    fields_new = [
+        "pod_name",
+        "uid",
+        "creation_timestamp",
+        "owner_references[0]['name']",
+        "node_name",
+        "service_account",
+        "scheduler_name",
+        "host_ip",
+        "pod_ip",
+        "start_time",
+    ]
+    fields_update = [
+        "deletion_timestamp",
+        "phase",
+        "restart_count",
+        "state",
+        "qos_class",
+        "status",
+        "message",
+        "reason",
+    ]
+    if not os.path.isfile(fname_complete):
+        open(fname_complete, "w").write(f"{', '.join(fields_new + fields_update)}\n")
+    if not os.path.isfile(filename):
+        open(filename, "w").write(f"{', '.join(fields_new + fields_update)}\n")
+
+    for dep_name in deployment_names:
+        pods_info = get_pods_status_info(deployment_name=dep_name, namespace=namespace)
+        pod_names = set(pods_info.keys())
+        df = pd.read_csv(filename, skipinitialspace=True)
+        df_pod_names = set(df["pod_name"])
+
+        # Pods in df but not in pod_names (to be removed and archived)
+        removed_pods = df_pod_names - pod_names
+        removed_rows = df[df["pod_name"].isin(removed_pods)]
+        df = df[~df["pod_name"].isin(removed_pods)]
+        if not removed_rows.empty:
+            removed_rows.to_csv(fname_complete, mode="a", header=False, index=False)
+
+        # Pods in both df and pod_names (update fields_update)
+        shared_pods = df_pod_names & pod_names
+        for pod_name in shared_pods:
+            idx = df.index[df["pod_name"] == pod_name][0]
+            for field in fields_update:
+                if field == "deletion_timestamp":
+                    if pods_info[pod_name][field] is not None:
+                        df.at[idx, field] = pods_info[pod_name][field].strftime(
+                            "%Y-%m-%d %H:%M:%S %Z"
+                        )
+                    else:
+                        df.at[idx, field] = None
+                else:
+                    df.at[idx, field] = pods_info[pod_name][field]
+
+        # Pods in pod_names but not in df (add new rows)
+        new_pods = pod_names - df_pod_names
+        for pod_name in new_pods:
+            pod_info = pods_info[pod_name]
+            row = {
+                field: pod_info.get(field, "") for field in fields_new + fields_update
+            }
+            row["owner_references[0]['name']"] = pod_info["owner_references"][0]["name"]
+            row["creation_timestamp"] = pod_info["creation_timestamp"].strftime(
+                "%Y-%m-%d %H:%M:%S %Z"
+            )
+            new_row_df = pd.DataFrame([row])
+            if (
+                not new_row_df.empty
+                and new_row_df.notnull().any().any()
+                and len(new_row_df) >= 1
+            ):
+                if not df.empty and df.notnull().any().any() and len(df) >= 1:
+                    df = pd.concat([new_row_df, df], ignore_index=True)
+                else:
+                    df = new_row_df
+
+        df.to_csv(filename, index=False)
+
+
+def monitor_pods(filename, keep_key="", timelag=20, namespace=None, silence=False):
+    """Monitor pod information and store in a file
+
+    Args:
+        filename (str): Filename to store pod information
+        timelag (int, optional): Time lag in seconds before updating. Defaults to 20.
+        keep_key (str, optional): A string in the deployment name to signify that it should be kept. Defaults to "".
+        namespace (str, optional): Kubernetes descriptor to indicate a set of team resources. Defaults to
+        :func:`kubecustom.secret.MyData.get_data```("namespace")``.
+        silence (bool, optional): Whether to silence warnings. Defaults to False.
+    """
+    namespace = MyDataInstance.get_data("namespace") if namespace is None else namespace
+    if silence:
+        warnings.filterwarnings("ignore")
+
+    kwargs = {
+        "filename": filename,
+        "keep_key": keep_key,
+        "namespace": namespace,
+    }
+
+    update_pods_status_info(**kwargs)
+    my_scheduler = sched.scheduler(time.time, time.sleep)
+    my_scheduler.enter(
+        timelag,
+        1,
+        repeat_task,
+        (my_scheduler, update_pods_status_info, kwargs, timelag),
+    )
+    my_scheduler.run()

--- a/kubecustom/pod.py
+++ b/kubecustom/pod.py
@@ -49,7 +49,8 @@ def get_pod_list(deployment_name=None, namespace=None):
     """Get a list of Kubernetes pod objects, optionally filtered by deployment.
 
     Args:
-        deployment_name (_type_, optional): Name of deployment to restrict pod list. Defaults to None.
+        deployment_name (str or list, optional): Name of deployment or list of deployment names to
+        restrict pod list. Defaults to None.
         namespace (str, optional): Kubernetes descriptor to indicate a set of team resources. Defaults to
         :func:`kubecustom.secret.MyData.get_data("namespace")`.
 
@@ -58,6 +59,8 @@ def get_pod_list(deployment_name=None, namespace=None):
     """
 
     namespace = MyDataInstance.get_data("namespace") if namespace is None else namespace
+    if isinstance(deployment_name, str):
+        deployment_name = [deployment_name]
 
     config.load_kube_config()
     pods = client.CoreV1Api().list_namespaced_pod(namespace=namespace)
@@ -68,7 +71,7 @@ def get_pod_list(deployment_name=None, namespace=None):
             if pod.metadata.owner_references is not None
             and all(
                 owner.kind == "ReplicaSet"
-                and "-".join(owner.name.split("-")[:-1]) == deployment_name
+                and "-".join(owner.name.split("-")[:-1]) in deployment_name
                 for owner in pod.metadata.owner_references
             )
         ]
@@ -204,7 +207,8 @@ def get_pods_status_info(previous=False, deployment_name=None, namespace=None):
 
     Args:
         previous (bool, optional): Obtain previous pod state. Defaults to False.
-        deployment_name (str, optional): Name of deployment to restrict pod list. Defaults to None.
+        deployment_name (str or list, optional): Name of deployment to restrict pod list, or list of deployment
+        names. Defaults to None.
         namespace (str, optional): Kubernetes descriptor to indicate a set of team resources. Defaults to
         :func:`kubecustom.secret.MyData.get_data("namespace")`.
 

--- a/kubecustom/pod.py
+++ b/kubecustom/pod.py
@@ -204,12 +204,43 @@ def get_pods_status_info(previous=False, deployment_name=None, namespace=None):
 
     Args:
         previous (bool, optional): Obtain previous pod state. Defaults to False.
-        deployment_name (_type_, optional): Name of deployment to restrict pod list. Defaults to None.
+        deployment_name (str, optional): Name of deployment to restrict pod list. Defaults to None.
         namespace (str, optional): Kubernetes descriptor to indicate a set of team resources. Defaults to
         :func:`kubecustom.secret.MyData.get_data("namespace")`.
 
     Returns:
-        list: List of Kubernetes pod objects ``kubernetes.client.models.v1_pod.V1Pod``
+        dict: Per pod information, where each key is a pod name and each value is a dictionary with:
+
+         - "pod_name" (str): Name of the pod
+         - "namespace" (str): Namespace that the pod is in
+         - "labels" (dict[str]): Dictionary of labels associated with the pod
+         - "annotations" (dict[str]): Dictionary of annotations on the pod containing some ids and IPs
+         - "creation_timestamp" (datetime): Timestamp when the pod was created
+         - "deletion_timestamp" (datetime or None): Timestamp when the pod was deleted, or None if not deleted
+         - "uid" (str): Unique identifier for the pod
+         - "owner_references" (list[dict]): List of owner reference dictionaries for the pod
+         - "node_name" (str): Name of the node the pod is scheduled on
+         - "service_account" (str): Name of the service account used by the pod
+         - "priority" (int or None): Priority value of the pod
+         - "scheduler_name" (str): Name of the scheduler used for the pod
+         - "containers" (list[str]): List of container names in the pod
+         - "init_containers" (list[str]): List of init container names in the pod
+         - "volumes" (list[str]): List of volume names attached to the pod
+         - "host_ip" (str): IP address of the host node
+         - "pod_ip" (str): IP address assigned to the pod
+         - "phase" (str): Current phase of the pod (e.g., Running, Pending)
+         - "restart_count" (int or None): Number of times the main container has restarted
+         - "state" (str or None): State of the pod ("running", "waiting", "terminated", or None)
+         - "status" (str or None): Status reason for the current state
+         - "status_info" (dict or None): Additional information about the pod status
+         - "start_time" (datetime or None): Time when the pod started
+         - "container_statuses" (list[dict]): List of container status dictionaries
+         - "init_container_statuses" (list[dict]): List of init container status dictionaries
+         - "conditions" (list[dict]): List of condition dictionaries for the pod
+         - "qos_class" (str or None): Quality of Service class assigned to the pod
+         - "message" (str or None): Message about the pod's status, if any
+         - "reason" (str or None): Reason for the pod's current condition, if any
+
     """
 
     namespace = MyDataInstance.get_data("namespace") if namespace is None else namespace
@@ -224,12 +255,30 @@ def get_pods_status_info(previous=False, deployment_name=None, namespace=None):
     for pod in pods:
         state, status, status_info = pod_state(pod, previous=previous)
         try:
-            restart_count = pod.status.container_statuses[0].restart_count
+            restart_count = pod.status.container_statuses[0]["restart_count"]
         except Exception:
             restart_count = None
+
         pod_info[pod.metadata.name] = {
             "pod_name": pod.metadata.name,
+            "namespace": pod.metadata.namespace,
+            "labels": pod.metadata.labels,
+            "annotations": pod.metadata.annotations,
+            "creation_timestamp": pod.metadata.creation_timestamp,
+            "deletion_timestamp": pod.metadata.deletion_timestamp,
+            "uid": pod.metadata.uid,
+            "owner_references": [
+                owner.to_dict() for owner in (pod.metadata.owner_references or [])
+            ],
             "node_name": pod.spec.node_name,
+            "service_account": pod.spec.service_account_name,
+            "priority": pod.spec.priority,
+            "scheduler_name": pod.spec.scheduler_name,
+            "containers": [container.name for container in pod.spec.containers],
+            "init_containers": [
+                container.name for container in (pod.spec.init_containers or [])
+            ],
+            "volumes": [volume.name for volume in (pod.spec.volumes or [])],
             "host_ip": pod.status.host_ip,
             "pod_ip": pod.status.pod_ip,
             "phase": pod.status.phase,
@@ -237,6 +286,17 @@ def get_pods_status_info(previous=False, deployment_name=None, namespace=None):
             "state": state,
             "status": status,
             "status_info": status_info,
+            "start_time": pod.status.start_time,
+            "container_statuses": [
+                cs.to_dict() for cs in (pod.status.container_statuses or [])
+            ],
+            "init_container_statuses": [
+                cs.to_dict() for cs in (pod.status.init_container_statuses or [])
+            ],
+            "conditions": [cond.to_dict() for cond in (pod.status.conditions or [])],
+            "qos_class": getattr(pod.status, "qos_class", None),
+            "message": getattr(pod.status, "message", None),
+            "reason": getattr(pod.status, "reason", None),
         }
 
     return pod_info

--- a/kubecustom/utils.py
+++ b/kubecustom/utils.py
@@ -247,7 +247,7 @@ def get_parser():
         "--timelag",
         dest="timelag",
         default=20,
-        help=("Time lag in seconds before updating. Defaults to 60"),
+        help=("Time lag in seconds before updating. Defaults to 20"),
     )
     parser.add_argument(
         "-s",

--- a/kubecustom/utils.py
+++ b/kubecustom/utils.py
@@ -19,6 +19,20 @@ except Exception:
     )
 
 
+def repeat_task(scheduler, function, kwargs, timelag=60):
+    """Repeat a task given a timelag until stopped.
+
+    Args:
+        scheduler (sched.scheduler): An instance of Python's sched.scheduler, which schedules tasks to run at specific times.
+        function (Callable): Function to repeat
+        kwargs (dict): keyword arguments for ``function``.
+        timelag (int, optional): Time lag in seconds before updating. Defaults to 60
+
+    """
+    scheduler.enter(timelag, 1, repeat_task, (scheduler, function, kwargs, timelag))
+    function(**kwargs)
+
+
 def convert_cpu_use(cpu_usage, issue_warnings=True):
     """Take a string indicating CPU usage and output a float of
     whole number of CPUs used.


### PR DESCRIPTION
## Description
In some cases pods (i.e., replicas) terminate and no longer have logs to obtain the reason. This PR adds a monitor that is updating information for pods that exist in a csv, and when they disappear, they are moved to another csv for archival.

## Status
- [ ] Ready to go